### PR TITLE
added 'd.foo().bar()' in Dummy

### DIFF
--- a/deeputil/misc.py
+++ b/deeputil/misc.py
@@ -450,5 +450,4 @@ class Dummy(object):
 
     def __call__(self, *args, **kwargs):
         self._log('__call__', dict(args=args, kwargs=kwargs, prefix=self._prefix))
-
-
+        return Dummy(__prefix__=self._prefix, __quiet__=self._quiet)


### PR DESCRIPTION
Previously Dummy object worked on Dummy().foo, Dummy.foo() but not Dummy.foo().bar()