### PR TITLE
Make (at least surface level) Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Commonly re-used logic
 ## 
 ## Installation
 > Prerequisites: Python3+
+
+Not cross-compatible with Windows before version 0.2.10
 ```
 sudo pip install deeputil
 ```

--- a/deeputil/misc.py
+++ b/deeputil/misc.py
@@ -489,17 +489,16 @@ class ExpiringCounter(object):
 
 
 # TODO Examples and Readme.md
-
 def set_file_limits(n):
     """
     Set the limit on number of file descriptors
     that this process can open. Only works on posix systems.
 
     """
-    
     try:
         if os.name == "posix":
             import resource
+
             # The resource module only exists on posix systems
             resource.setrlimit(resource.RLIMIT_NOFILE, (n, n))
             return True

--- a/deeputil/misc.py
+++ b/deeputil/misc.py
@@ -499,6 +499,7 @@ def set_file_limits(n):
     
     try:
         if os.name == "posix":
+            import resource
             # The resource module only exists on posix systems
             resource.setrlimit(resource.RLIMIT_NOFILE, (n, n))
             return True

--- a/deeputil/misc.py
+++ b/deeputil/misc.py
@@ -489,19 +489,21 @@ class ExpiringCounter(object):
 
 
 # TODO Examples and Readme.md
-import resource
-
 
 def set_file_limits(n):
     """
     Set the limit on number of file descriptors
-    that this process can open.
+    that this process can open. Only works on posix systems.
 
     """
-
+    
     try:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (n, n))
-        return True
+        if os.name == "posix":
+            # The resource module only exists on posix systems
+            resource.setrlimit(resource.RLIMIT_NOFILE, (n, n))
+            return True
+        else:
+            return False
     except ValueError:
         return False
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name="deeputil",
-    version="0.2.9",
+    version="0.2.10",
     description="Commonly re-used logic kept in one library",
     keywords="deeputil",
     author="Deep Compute, LLC",


### PR DESCRIPTION
This allows for the module to at least be imported on a Windows system. Because the `import resource` was sitting in the file, Windows systems could not import this module at all. I added a check for OS type and moved the import to the function so that it reduces memory usage if that function is not being used. Also bumped a minor version as it changes compatibility.

There may be some other Windows incompatibilities but with my brief look through I didn't see any.

I would also recommend moving some of the other imports into the functions they are applicable to as it would reduce the memory footprint if those functions are not used. Unless of course they are being called very often, then I would move the imports up to the top of the file for PEP8 conformity.